### PR TITLE
feat: reduce minimal window height

### DIFF
--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -5,7 +5,7 @@ template $LockWindow : Adw.ApplicationWindow {
     default-width: 900;
     default-height: 600;
     width-request: 350;
-    height-request: 500;
+    height-request: 350;
     title: _("Lock");
     icon-name: "com.konstantintutsch.Lock";
 


### PR DESCRIPTION
Hi, thanks for creating this app!

Since, according to [metainfo](https://github.com/konstantintutsch/Lock/blob/7d06582b72fc41b7021bf52cc3b6e4ce3c101b47/data/com.konstantintutsch.Lock.metainfo.xml.in.in#L71), having this app working on mobile/small screens is a goal, here's a tiny fix, as I had issues with the current minimal height (see screenshot below) on my Pixel 3a:
![Lock-too-high](https://github.com/user-attachments/assets/acf22773-b457-4cd7-8ec7-514ab39814f3)

I have reduced the height more than may seem necessary - the goal is to also fix this for devices with 720 x 1280px screens (360 x 640 logical pixels), see also https://linuxphoneapps.org/docs/resources/developer-information/#hardware-specs-to-consider

Thanks again!