### PR TITLE
fix: use plural in strings for key import

### DIFF
--- a/data/ui/keydialog.blp
+++ b/data/ui/keydialog.blp
@@ -68,8 +68,8 @@ template $LockKeyDialog : Adw.Dialog {
                                     Gtk.Button import_button {
                                         styles ["pill", "suggested-action"]
 
-                                        label: C_("Import key(s) from file", "Import");
-                                        tooltip-text: _("Import key(s) from file");
+                                        label: C_("Import keys from files", "Import");
+                                        tooltip-text: _("Import keys from files");
                                     }
 
                                     Gtk.Button create_button {

--- a/po/bg.po
+++ b/po/bg.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.konstantintutsch.Lock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-24 20:01+0200\n"
+"POT-Creation-Date: 2024-10-24 21:12+0200\n"
 "PO-Revision-Date: 2024-10-23 00:58+0200\n"
 "Last-Translator: twlvnn kraftwerk <kraft_werk@tutanota.com>\n"
 "Language-Team: Bulgarian <dict-notifications@fsa-bg.org>\n"
@@ -115,7 +115,8 @@ msgid "Import failed"
 msgstr "Внасянето е неуспешно"
 
 #: src/keydialog.c:329
-msgid "Key(s) imported"
+#, fuzzy
+msgid "Keys imported"
 msgstr "Внесено"
 
 #: src/keydialog.c:396
@@ -521,13 +522,15 @@ msgid "Your system does not store any GnuPG keys."
 msgstr "Вашата система не съхранява GnuPG ключове."
 
 #: data/ui/keydialog.blp:71
-msgctxt "Import key(s) from file"
+#, fuzzy
+msgctxt "Import keys from files"
 msgid "Import"
 msgstr "Внасяне"
 
 #: data/ui/keydialog.blp:72
-msgid "Import key(s) from file"
-msgstr "Внасяне на ключ(ове) от файл"
+#: data/com.konstantintutsch.Lock.metainfo.xml.in.in:21
+msgid "Import keys from files"
+msgstr "Внасяйте ключове от файлове"
 
 #: data/ui/keydialog.blp:79
 msgid "Create a new keypair"
@@ -652,10 +655,6 @@ msgstr "Преглеждайте датите на изтичане"
 msgid "Export public keys to files"
 msgstr "Изнасяйте публични ключове от файлове"
 
-#: data/com.konstantintutsch.Lock.metainfo.xml.in.in:21
-msgid "Import keys from files"
-msgstr "Внасяйте ключове от файлове"
-
 #: data/com.konstantintutsch.Lock.metainfo.xml.in.in:22
 msgid "Generate new keypairs"
 msgstr "Генерирайте нови ключове"
@@ -691,6 +690,9 @@ msgstr "Обикновен текст"
 #: data/com.konstantintutsch.Lock.metainfo.xml.in.in:70
 msgid "User ID dialog"
 msgstr "Прозорец за идентификатор на потребителя"
+
+#~ msgid "Import key(s) from file"
+#~ msgstr "Внасяне на ключ(ове) от файл"
 
 #~ msgid "Backup keys"
 #~ msgstr "Създаване на резерва"

--- a/po/com.konstantintutsch.Lock.pot
+++ b/po/com.konstantintutsch.Lock.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.konstantintutsch.Lock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-24 20:01+0200\n"
+"POT-Creation-Date: 2024-10-24 21:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -113,7 +113,7 @@ msgid "Import failed"
 msgstr ""
 
 #: src/keydialog.c:329
-msgid "Key(s) imported"
+msgid "Keys imported"
 msgstr ""
 
 #: src/keydialog.c:396
@@ -518,12 +518,13 @@ msgid "Your system does not store any GnuPG keys."
 msgstr ""
 
 #: data/ui/keydialog.blp:71
-msgctxt "Import key(s) from file"
+msgctxt "Import keys from files"
 msgid "Import"
 msgstr ""
 
 #: data/ui/keydialog.blp:72
-msgid "Import key(s) from file"
+#: data/com.konstantintutsch.Lock.metainfo.xml.in.in:21
+msgid "Import keys from files"
 msgstr ""
 
 #: data/ui/keydialog.blp:79
@@ -645,10 +646,6 @@ msgstr ""
 
 #: data/com.konstantintutsch.Lock.metainfo.xml.in.in:20
 msgid "Export public keys to files"
-msgstr ""
-
-#: data/com.konstantintutsch.Lock.metainfo.xml.in.in:21
-msgid "Import keys from files"
 msgstr ""
 
 #: data/com.konstantintutsch.Lock.metainfo.xml.in.in:22

--- a/po/cs.po
+++ b/po/cs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.konstantintutsch.Lock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-24 20:01+0200\n"
+"POT-Creation-Date: 2024-10-24 21:12+0200\n"
 "PO-Revision-Date: 2024-10-20 11:55+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -114,7 +114,8 @@ msgid "Import failed"
 msgstr "Import selhal"
 
 #: src/keydialog.c:329
-msgid "Key(s) imported"
+#, fuzzy
+msgid "Keys imported"
 msgstr "Klíč(e) importován(y)"
 
 #: src/keydialog.c:396
@@ -528,13 +529,13 @@ msgstr "Ve vašem systému nejsou uloženy žádné GnuPG klíče."
 
 #: data/ui/keydialog.blp:71
 #, fuzzy
-msgctxt "Import key(s) from file"
+msgctxt "Import keys from files"
 msgid "Import"
 msgstr "Importovat"
 
 #: data/ui/keydialog.blp:72
-#, fuzzy
-msgid "Import key(s) from file"
+#: data/com.konstantintutsch.Lock.metainfo.xml.in.in:21
+msgid "Import keys from files"
 msgstr "Importovat klíče ze souborů"
 
 #: data/ui/keydialog.blp:79
@@ -664,10 +665,6 @@ msgstr "Zobrazit datum platnosti"
 msgid "Export public keys to files"
 msgstr "Exportovat veřejné klíče do souborů"
 
-#: data/com.konstantintutsch.Lock.metainfo.xml.in.in:21
-msgid "Import keys from files"
-msgstr "Importovat klíče ze souborů"
-
 #: data/com.konstantintutsch.Lock.metainfo.xml.in.in:22
 #, fuzzy
 msgid "Generate new keypairs"
@@ -705,6 +702,10 @@ msgstr "Holý text"
 #: data/com.konstantintutsch.Lock.metainfo.xml.in.in:70
 msgid "User ID dialog"
 msgstr "Okno s ID uživatele"
+
+#, fuzzy
+#~ msgid "Import key(s) from file"
+#~ msgstr "Importovat klíče ze souborů"
 
 #, fuzzy
 #~ msgctxt "GPGME Error"

--- a/po/de.po
+++ b/po/de.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.konstantintutsch.Lock\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-24 20:01+0200\n"
-"PO-Revision-Date: 2024-10-24 19:40+0200\n"
+"POT-Creation-Date: 2024-10-24 21:12+0200\n"
+"PO-Revision-Date: 2024-10-24 21:13+0200\n"
 "Last-Translator: Konstantin Tutsch <mail@konstantintutsch.com>\n"
 "Language-Team: German\n"
 "Language: de\n"
@@ -115,7 +115,7 @@ msgid "Import failed"
 msgstr "Import fehlgeschlagen"
 
 #: src/keydialog.c:329
-msgid "Key(s) imported"
+msgid "Keys imported"
 msgstr "Schlüssel importiert"
 
 #: src/keydialog.c:396
@@ -523,13 +523,14 @@ msgid "Your system does not store any GnuPG keys."
 msgstr "Ihr System speichert keine GnuPG Schlüssel."
 
 #: data/ui/keydialog.blp:71
-msgctxt "Import key(s) from file"
+msgctxt "Import keys from files"
 msgid "Import"
 msgstr "Importieren"
 
 #: data/ui/keydialog.blp:72
-msgid "Import key(s) from file"
-msgstr "Schlüssel aus Datei importieren"
+#: data/com.konstantintutsch.Lock.metainfo.xml.in.in:21
+msgid "Import keys from files"
+msgstr "Schlüssel aus Dateien importieren"
 
 #: data/ui/keydialog.blp:79
 msgid "Create a new keypair"
@@ -656,10 +657,6 @@ msgstr "Ablaufzeitpunkte ansehen"
 msgid "Export public keys to files"
 msgstr "Öffentliche Schlüssel in Dateien exportieren"
 
-#: data/com.konstantintutsch.Lock.metainfo.xml.in.in:21
-msgid "Import keys from files"
-msgstr "Schlüssel aus Dateien importieren"
-
 #: data/com.konstantintutsch.Lock.metainfo.xml.in.in:22
 msgid "Generate new keypairs"
 msgstr "Neue Schlüsselpaare generieren"
@@ -695,6 +692,9 @@ msgstr "Klartext"
 #: data/com.konstantintutsch.Lock.metainfo.xml.in.in:70
 msgid "User ID dialog"
 msgstr "Nutzer ID Dialog"
+
+#~ msgid "Import key(s) from file"
+#~ msgstr "Schlüssel aus Datei importieren"
 
 #~ msgid "Remove key and all subkeys"
 #~ msgstr "Schlüssel und alle Unterschlüssel entfernen"

--- a/src/keydialog.c
+++ b/src/keydialog.c
@@ -326,7 +326,7 @@ gboolean lock_key_dialog_import_on_completed(LockKeyDialog *dialog)
     if (!dialog->import_success) {
         toast = adw_toast_new(_("Import failed"));
     } else {
-        toast = adw_toast_new(_("Key(s) imported"));
+        toast = adw_toast_new(_("Keys imported"));
     }
 
     adw_toast_set_timeout(toast, 2);


### PR DESCRIPTION
<!-- Coders, explain the bug you are fixing (unless an issue for it already exists) or the benefit of the feature you are implementing. -->
<!-- Translators, remember to add add yourself to the translation-credits while translating. -->
