### PR TITLE
build: Move gresource file into vendorized sub-directory.

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -66,6 +66,6 @@ gnome.compile_resources(
   dependencies: [appstream_file, ui],
   gresource_bundle: true,
   install: true,
-  install_dir: datadir
+  install_dir: datadir / project_id
 )
 

--- a/meson.build
+++ b/meson.build
@@ -56,7 +56,7 @@ conf.set('localedir', localedir)
 #
 
 gettext_package = project_id
-gresource_file = datadir / project_id + '.gresource'
+gresource_file = datadir / project_id / project_id + '.gresource'
 ui_resource = project_root / 'ui'
 
 conf.set('gettext_package', gettext_package)


### PR DESCRIPTION
By the recent Filesystem Hierarchy Standard (FHS v3.0), it is recommended that a subdirectory located inside of /usr/share (or /usr/local/share, if installed locally) is to be used to store read-only data used by an application.

See:  https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s11.html